### PR TITLE
Run CI on mac and Windows too

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,6 +17,8 @@ jobs:
           - '1'
         os:
           - ubuntu-latest
+          - macos-latest
+          - windows-latest
     steps:
       - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@v1


### PR DESCRIPTION
This is just a quick test.. but looking at https://github.com/JuliaDocs/Documenter.jl/pull/2375/files, I suspect there is some missing `\r` handling or something that breaks things on Windows.