### PR TITLE
Check in `.vscode` with formatting configuration

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "jkillian.custom-local-formatters"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+    "customLocalFormatters.formatters": [
+        {
+            "command": "julia --project=@runic -e 'using Runic; exit(Runic.main(ARGS))'",
+            "languages": [
+                "julia"
+            ]
+        }
+    ],
+    "[julia]": {
+        "editor.defaultFormatter": "jkillian.custom-local-formatters"
+    },
+}


### PR DESCRIPTION
This uses VSCode's workspace settings features to configure julia formatting to be via runic as described in https://github.com/fredrikekre/Runic.jl?tab=readme-ov-file#vs-code.

I use VSCode for julia and have a lot of projects that don't use runic, so I would like some local configuration. I think two reasonable options here are this PR, or a different one that just adds `.vscode` to gitignore.

Any preference @fredrikekre ?